### PR TITLE
Add marimo configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 ]
 dependencies = [
   "marimo",
+  "marimo[lsp]", # marimo language server protocol
   "ruff",
   "nbconvert",
   "polars",
@@ -48,3 +49,13 @@ select = [
 ]
 # Can use to ignore specific rules within above selection
 ignore = []
+
+[tool.marimo.display]
+cell_output = "below"
+
+[tool.marimo.runtime]
+# Add project source directory to Python path
+pythonpath = ["src"]
+
+[tool.marimo.save]
+format_on_save = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,6 @@ pythonpath = ["src"]
 
 [tool.marimo.save]
 format_on_save = true
+
+[tool.marimo.experimental]
+lsp = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,5 +60,8 @@ pythonpath = ["src"]
 [tool.marimo.save]
 format_on_save = true
 
+[tool.marimo.diagnostics]
+enabled = true
+
 [tool.marimo.experimental]
 lsp = true

--- a/src/remarx/__init__.py
+++ b/src/remarx/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.1.exp1"
+__version__ = "0.0.1.dev1"


### PR DESCRIPTION
ref: #21 

### Key Changes
- Fixed invalid version number
- Added `marimo` configuration settings to `pypackage.toml`
  - Sets cell output to be displayed _below_ the cell itself
  - Sets notebooks to be reformatted on save
  - Enable marimo [LSP](https://docs.marimo.io/guides/editor_features/language_server/)

### Notes
- For this PR make sure to (re)install the package dependencies.
- To get updated LSP/diagnostic messages within the `marimo` editor, you may need to restart the kernel
### Evaluation
- [x] Check updated version number
- [x] Check that notebooks are reformatted on saves
- [x] Check that cell output is displayed _below_ the cell
- [x] Check user settings within the `marimo` editor (see below criteria)
  - [x] There is a warning that "Format on save" is overwritten by pyproject.toml which is set to true
  - [x] The Python Language Server is turned on
  - [x] The Diagnostics is turned on
- [x] Check that the LSP/Diagnostics features work (see below criteria)
  - [x] Imports produce a warning (yellow triangle) about formatting
  - [x] Deleting the `import polars as pl` line produces errors (red circles) for the subsequent code lines that invoke it