### PR TITLE
Experiments/sandbox utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ pre-commit install
 This branch contains code and data for preliminary experiments with
 Princeton's AI Sandbox.
 
+### AI Sandbox API key setup
+
+In order to use the AI Sandbox API, you must have a API key. You must set the
+environment variable `AI_SANDBOX_KEY` to your API key value. Do this by creating
+a `.env` file in the same directory as the `pyproject.toml` with the following
+line:
+```
+AI_SANDBOX_KEY=[your_api_key]
+```
 
 ### Marimo notebook setup
 

--- a/src/remarx/sandbox_utils.py
+++ b/src/remarx/sandbox_utils.py
@@ -24,14 +24,14 @@ def create_client() -> AzureOpenAI:
     )
 
 
-def run_basic_text_prompt(
+def submit_prompt(
     task_prompt,
     user_prompt,
     model="gpt-4o",
 ) -> ChatCompletion:
     """
-    Run basic text prompt using given model with task- and user-level prompts.
-    Returns resulting response object.
+    Submits basic text prompt using given model with task- and user-level
+    prompts. Returns resulting response object.
     """
     # Establish a connection to your Azure OpenAI instance
     client = create_client()

--- a/src/remarx/sandbox_utils.py
+++ b/src/remarx/sandbox_utils.py
@@ -1,0 +1,47 @@
+"""
+Utility functions for working with the AI Sandbox
+"""
+
+import os
+
+from openai import AzureOpenAI
+from openai.types.chat import ChatCompletion
+
+# AI Sandbox variables
+SANDBOX_API_KEY = os.environ["AI_SANDBOX_KEY"]
+SANDBOX_ENDPOINT = "https://api-ai-sandbox.princeton.edu"
+SANDBOX_API_VERSION = "2024-02-01"
+
+
+def create_client() -> AzureOpenAI:
+    """
+    Create an AI Sandbox client
+    """
+    return AzureOpenAI(
+        api_key=SANDBOX_API_KEY,
+        azure_endpoint=SANDBOX_ENDPOINT,
+        api_version=SANDBOX_API_VERSION,
+    )
+
+
+def run_basic_text_prompt(
+    task_prompt,
+    user_prompt,
+    model="gpt-4o",
+) -> ChatCompletion:
+    """
+    Run basic text prompt using given model with task- and user-level prompts.
+    Returns resulting response object.
+    """
+    # Establish a connection to your Azure OpenAI instance
+    client = create_client()
+
+    # TODO: Determine what optional parameters should be customizable
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": task_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+    )
+    return response


### PR DESCRIPTION
ref: #10 

### Key Changes
- Add basic AI sandbox utilities to create a client and run a basic text prompt
- Updated README with instructions on setting up environment with the API sandbox key

### Notes
- marimo has been configured so that it knows about the `remarx` package and so it can be directly imported
- Make sure to set up your local `.env` file

### Evaluation

- [x] Check that the sandbox utility methods can be called from a marimo notebook and run as expected