### PR TITLE
Add aliases for scripts for easier use when installed as a package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ dev = [
 ]
 
 [project.scripts]
-candidate-mentions = "remarx.candidate_mentions:main"
-run-xslt = "remarx.run_xslt:main"
+remarx-candidate-mentions = "remarx.candidate_mentions:main"
+remarx-run-xslt = "remarx.run_xslt:main"
 
 [tool.hatch.version]
 path = "src/remarx/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ dev = [
   "pre-commit",
 ]
 
+[project.scripts]
+candidate-mentions = "remarx.candidate_mentions:main"
+run-xslt = "remarx.run_xslt:main"
+
 [tool.hatch.version]
 path = "src/remarx/__init__.py"
 


### PR DESCRIPTION
**Associated Issue:** ~ #43 

### Changes in this PR

- Update pyproject.toml to install candidate mentions and run xslt as project scripts

### Notes

- Adding this so I can easily run the candidate mentions script on della

### Evaluation

- [x] Confirm you can install the package and the commands are available at the specified aliases
