### PR TITLE
Adapt Experiment 2  script to generate sentences corpus

### DIFF
--- a/src/remarx/build_sentence_corpus.py
+++ b/src/remarx/build_sentence_corpus.py
@@ -1,0 +1,89 @@
+"""
+Parse documents into a sentence corpus file (JSONL).
+
+NOTE: Not being used for title mentions because it's
+too slow (need to pass each "sentence" to stanza).
+"""
+
+import argparse
+import pathlib
+import sys
+from typing import Generator
+
+import orjsonl
+import stanza
+from tqdm import tqdm
+
+
+def get_sentences(
+    input_dir: pathlib.Path,
+    lang: str,
+) -> Generator[dict[str : str | int], None, None]:
+    """
+    Split each document into sentences. Yield these sentences as
+    JSON objects containing the sentence's text along with its
+    file and offset information.
+    """
+    pipeline = stanza.Pipeline(lang=lang, processors="tokenize")
+
+    file_progress = tqdm(input_dir.rglob("*.txt"))
+
+    for text in file_progress:
+        file_progress.set_description_str(f"Processing {text.stem}")
+        for i, sentence in enumerate(pipeline(text.read_text()).sentences):
+            entry = {
+                "file": text.stem,
+                "sent_idx": i,
+                "char_idx": sentence.tokens[0].start_char,
+                "text": sentence.text,
+            }
+            yield entry
+
+
+def save_sentences(
+    input_dir: pathlib.Path,
+    out_filename: pathlib.Path,
+    lang: str = "de",
+):
+    orjsonl.save(out_filename, get_sentences(input_dir, lang))
+
+
+def main():
+    """
+    Command-line access for parsing documents into a sentences corpus file (JSONL).
+    """
+    parser = argparse.ArgumentParser(
+        description="Build sentence corpus",
+    )
+    parser.add_argument(
+        "input",
+        help="Input directory containing texts to search",
+        type=pathlib.Path,
+    )
+    parser.add_argument(
+        "output",
+        help="Filename where resulting sentence corpus should be saved (JSONL; compressed or not)",
+        type=pathlib.Path,
+    )
+
+    args = parser.parse_args()
+
+    # Validate arguments
+    if not args.input.is_dir():
+        print(f"Error: input directory {args.input} does not exist", file=sys.stderr)
+        sys.exit(1)
+    if args.output.is_file():
+        print(
+            f"Error: output file {args.output} exsts. Will not overwrite.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    save_sentences(
+        args.input,
+        args.output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/remarx/build_sentence_corpus.py
+++ b/src/remarx/build_sentence_corpus.py
@@ -1,8 +1,13 @@
 """
-Parse documents into a sentence corpus file (JSONL).
+Parse text documents into a sentence corpus file (JSONL).
+Uses Stanza pipeline; language assumes German.
 
-NOTE: Not being used for title mentions because it's
-too slow (need to pass each "sentence" to stanza).
+Takes an input directory and an output file name.
+
+Example usage:
+
+  python build_sentence_corpus.py input_textdir/ sent.jsonl
+
 """
 
 import argparse
@@ -77,7 +82,7 @@ def main():
         sys.exit(1)
     if args.output.is_file():
         print(
-            f"Error: output file {args.output} exsts. Will not overwrite.",
+            f"Error: output file {args.output} exists. Will not overwrite.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/src/remarx/build_sentence_corpus.py
+++ b/src/remarx/build_sentence_corpus.py
@@ -29,10 +29,11 @@ def get_sentences(
     file_progress = tqdm(input_dir.rglob("*.txt"))
 
     for text in file_progress:
-        file_progress.set_description_str(f"Processing {text.stem}")
+        file_progress.set_description_str(f"Processing {text.name}")
         for i, sentence in enumerate(pipeline(text.read_text()).sentences):
             entry = {
-                "file": text.stem,
+                "file": text.name,
+                "sent_id": f"{text.stem}:{i:04d}",
                 "sent_idx": i,
                 "char_idx": sentence.tokens[0].start_char,
                 "text": sentence.text,
@@ -58,10 +59,12 @@ def main():
     parser.add_argument(
         "input",
         help="Input directory containing texts to search",
+        metavar="input_dir",
         type=pathlib.Path,
     )
     parser.add_argument(
         "output",
+        metavar="output_file",
         help="Filename where resulting sentence corpus should be saved (JSONL; compressed or not)",
         type=pathlib.Path,
     )


### PR DESCRIPTION
**Associated Issue:** #81

### Changes in this PR

- Checked out sentence corpus script from experiment 2 and modified slightly

### Notes

- Use full filename instead of just stem
- use argparse metavar to remind/indicate that input is a directory
- add sentence id based on filename stem and sentence index

### Evaluation

- [x] Check that you can run the script locally; can test with the sample pages from MEGA
- [x] Confirm that sentence ids are good enough for now
